### PR TITLE
Fix incorrect use of kalama glyph as comment for kama entry

### DIFF
--- a/ahk-script/sitelen-pona-5.1.ahk
+++ b/ahk-script/sitelen-pona-5.1.ahk
@@ -41,7 +41,7 @@ Hotstring("EndChars", "``")
 ::jaki::{U+F1910} ; 󱤐
 ::jelo::{U+F1912} ; 󱤒
 ::kala::{U+F1914} ; 󱤔
-::kama::{U+F1916} ; 󱤕
+::kama::{U+F1916} ; 󱤖
 ::kasi::{U+F1917} ; 󱤗
 ::kili::{U+F191A} ; 󱤚
 ::kule::{U+F191E} ; 󱤞


### PR DESCRIPTION
Stumbled upon this by chance. I've verified that there are no other duplicates with this quick-and-dirty command-line Python:
```py
import re
text = """
::kijetesantakalu::{U+F1980} ; 󱦀
::misikeke::{U+F1987} ; 󱦇
::kokosila::{U+F1984} ; 󱦄
::kepeken::{U+F1919} ; 󱤙
::sitelen::{U+F1960} ; 󱥠
::monsuta::{U+F197D} ; 󱥽
::lanpan::{U+F1985} ; 󱦅
::kalama::{U+F1915} ; 󱤕
::kulupu::{U+F191F} ; 󱤟
::pakala::{U+F1948} ; 󱥈
::palisa::{U+F194A} ; 󱥊 
::pimeja::{U+F194F} ; 󱥏
::sijelo::{U+F195B} ; 󱥛
::sinpin::{U+F195F} ; 󱥟
::soweli::{U+F1962} ; 󱥢
::majuna::{U+F19A2} ; 󱦢
::namako::{U+F1978} ; 󱥸
::kipisi::{U+F197B} ; 󱥻
::jasima::{U+F197F} ; 󱥿
::akesi::{U+F1901} ; 󱤁
::apeja::{U+F19A1} ; 󱦡
::kiwen::{U+F191B} ; 󱤛
::linja::{U+F1929} ; 󱤩
::lukin::{U+F192E} ; 󱤮
::monsi::{U+F1938} ; 󱤸
::nanpa::{U+F193D} ; 󱤽
::nasin::{U+F193F} ; 󱤿
::pilin::{U+F194E} ; 󱥎
::tenpo::{U+F196B} ; 󱥫
::utala::{U+F1971} ; 󱥱
::tonsi::{U+F197E} ; 󱥾
::epiku::{U+F1983} ; 󱦃
::alasa::{U+F1903} ; 󱤃
::insa::{U+F190F} ; 󱤏
::jaki::{U+F1910} ; 󱤐
::jelo::{U+F1912} ; 󱤒
::kala::{U+F1914} ; 󱤔
::kama::{U+F1916} ; 󱤕
::kasi::{U+F1917} ; 󱤗
::kili::{U+F191A} ; 󱤚
::kule::{U+F191E} ; 󱤞
::kute::{U+F1920} ; 󱤠
::lape::{U+F1922} ; 󱤢
::laso::{U+F1923} ; 󱤣
::lawa::{U+F1924} ; 󱤤
::lete::{U+F1926} ; 󱤦
::lili::{U+F1928} ; 󱤨
::lipu::{U+F192A} ; 󱤪
::loje::{U+F192B} ; 󱤫
::luka::{U+F192D} ; 󱤭
::lupa::{U+F192F} ; 󱤯
::mama::{U+F1931} ; 󱤱
::mani::{U+F1932} ; 󱤲
::mije::{U+F1935} ; 󱤵
::moku::{U+F1936} ; 󱤶
::moli::{U+F1937} ; 󱤷
::musi::{U+F193B} ; 󱤻
::mute::{U+F193C} ; 󱤼
::nasa::{U+F193E} ; 󱤾
::nena::{U+F1940} ; 󱥀
::nimi::{U+F1942} ; 󱥂
::noka::{U+F1943} ; 󱥃
::olin::{U+F1945} ; 󱥅
::open::{U+F1947} ; 󱥇
::pake::{U+F19A0} ; 󱦠
::pali::{U+F1949} ; 󱥉
::pana::{U+F194C} ; 󱥌
::pini::{U+F1950} ; 󱥐
::pipi::{U+F1951} ; 󱥑
::poka::{U+F1952} ; 󱥒
::poki::{U+F1953} ; 󱥓
::pona::{U+F1954} ; 󱥔
::powe::{U+F19A3} ; 󱦣
::sama::{U+F1956} ; 󱥖
::seli::{U+F1957} ; 󱥗
::selo::{U+F1958} ; 󱥘
::seme::{U+F1959} ; 󱥙
::sewi::{U+F195A} ; 󱥚
::sike::{U+F195C} ; 󱥜
::sina::{U+F195E} ; 󱥞
::sona::{U+F1961} ; 󱥡
::suli::{U+F1963} ; 󱥣
::suno::{U+F1964} ; 󱥤
::supa::{U+F1965} ; 󱥥
::suwi::{U+F1966} ; 󱥦
::taso::{U+F1968} ; 󱥨
::tawa::{U+F1969} ; 󱥩
::telo::{U+F196A} ; 󱥪
::toki::{U+F196C} ; 󱥬
::tomo::{U+F196D} ; 󱥭
::unpa::{U+F196F} ; 󱥯
::walo::{U+F1972} ; 󱥲
::waso::{U+F1974} ; 󱥴
::wawa::{U+F1975} ; 󱥵
::weka::{U+F1976} ; 󱥶
::wile::{U+F1977} ; 󱥷
::leko::{U+F197C} ; 󱥼
::soko::{U+F1981} ; 󱦁
::meso::{U+F1982} ; 󱦂
::meli::{U+F1933} ; 󱤳
::anpa::{U+F1905} ; 󱤅
::ante::{U+F1906} ; 󱤆
::awen::{U+F1908} ; 󱤈
::esun::{U+F190B} ; 󱤋
::ilo::{U+F190E} ; 󱤎
::jan::{U+F1911} ; 󱤑
::ken::{U+F1918} ; 󱤘
::kon::{U+F191D} ; 󱤝
::len::{U+F1925} ; 󱤥
::lon::{U+F192C} ; 󱤬
::mun::{U+F193A} ; 󱤺
::ona::{U+F1946} ; 󱥆
::pan::{U+F194B} ; 󱥋
::sin::{U+F195D} ; 󱥝
::tan::{U+F1967} ; 󱥧
::uta::{U+F1970} ; 󱥰
::wan::{U+F1973} ; 󱥳
::kin::{U+F1979} ; 󱥹
::oko::{U+F197A} ; 󱥺
::ike::{U+F190D} ; 󱤍
::ala::{U+F1902} ; 󱤂
::ale::{U+F1904} ; 󱤄
::anu::{U+F1907} ; 󱤇
::ijo::{U+F190C} ; 󱤌
::jo::{U+F1913} ; 󱤓
::ko::{U+F191C} ; 󱤜
::la::{U+F1921} ; 󱤡
::li::{U+F1927} ; 󱤧
::ma::{U+F1930} ; 󱤰
::mi::{U+F1934} ; 󱤴
::mu::{U+F1939} ; 󱤹
::ni::{U+F1941} ; 󱥁
::pi::{U+F194D} ; 󱥍
::pu::{U+F1955} ; 󱥕
::te::{U+300C} ; 「 start quote
::to::{U+300D} ; 」 end quote
::tu::{U+F196E} ; 󱥮
::ku::{U+F1988} ; 󱦈
::en::{U+F190A} ; 󱤊
::o::{U+F1944} ; 󱥄
::n::{U+F1986} ; 󱦆
::a::{U+F1900} ; 󱤀
::e::{U+F1909} ; 󱤉

::linluwi::{U+F19A4} ; 
::kiki::{U+F19A5} ; 
::su::{U+F19A6} ; 
::isipin::{U+F19A7} ; 
::jami::{U+F19A8} ; 
::jonke::{U+F19A9} ; 
::kamalawala::{U+F19AA} ; 
::kapesi::{U+F19AB} ; 
::konwe::{U+F19AC} ; 
::kulijo::{U+F19AD} ; 
::melome::{U+F19AE} ; 
::mijomi::{U+F19AF} ; 
::misa::{U+F19B0} ; 
::mulapisu::{U+F19B1} ; 
::nimisin::{U+F19B2} ; 
::nja::{U+F19B3} ; 
::ojuta::{U+F19B4} ; 
::oke::{U+F19B5} ; 
::omekapo::{U+F19B6} ; 
::owe::{U+F19B7} ; 
::pakola::{U+F19B8} ; 
::penpo::{U+F19B9} ; 
::pika::{U+F19BA} ; 
::po::{U+F19BB} ; 
::puwa::{U+F19BC} ; 
::san::{U+F19BD} ; 
::soto::{U+F19BE} ; 
::teje::{U+F19BF} ; 
::sutopatikuna::{U+F19C0} ; 
::taki::{U+F19C1} ; 
::unu::{U+F19C2} ; 
::usawi::{U+F19C3} ; 
::wa::{U+F19C4} ; 
::wasoweli::{U+F19C5} ; 
::wekama::{U+F19C6} ; 
::wuwojiti::{U+F19C7} ; 
::yupekosi::{U+F19C8} ; 
::eliki::{U+F19C9} ; 

::[::{U+F1990} ; cartouche start
::]::{U+F1991} ; cartouche end
::=::{U+F1992} ; cartouche extender (not usually necessary)

::|::{U+200C} ; zero width non joiner
::&::{U+200D} ; zero width joiner
::+::{U+F1996} ; scaling joiner
::-::{U+F1995} ; stacking joiner

::(::{U+F1997} ; start left-combining (normal) long glyph
::)::{U+F1998} ; end left-combining (normal) long glyph
::_::{U+F1999} ; container extender (not usually necessary)

::{::{U+F199A} ; start right-combining (reversed) long glyph
::}::{U+F199B} ; end right-combining (reversed) long glyph

::.::{U+F199C} ; sitelen pona full stop
::`:::{U+F199D} ; sitelen pona colon

::"::{U+3099} ; dakuten
::*::{U+309A} ; handakuten

::`s`s::{U+3000} ; logograph fullwidth space
::zz::{U+3000} ; logograph fullwidth space

::^`<::{U+200D}{U+2196} ; arrow NW
::`<^::{U+200D}{U+2196} ; arrow NW
::^`>::{U+200D}{U+2197} ; arrow NE
::`>^::{U+200D}{U+2197} ; arrow NE
::v`>::{U+200D}{U+2198} ; arrow SE
::`>v::{U+200D}{U+2198} ; arrow SE
::v`<::{U+200D}{U+2199} ; arrow SW
::`<v::{U+200D}{U+2199} ; arrow SW

::`<::{U+200D}{U+2190} ; arrow W
::^::{U+200D}{U+2191} ; arrow N
::`>::{U+200D}{U+2192} ; arrow E
::v::{U+200D}{U+2193} ; arrow S

::1::{U+FE00} ; variation selector 1
::2::{U+FE01} ; variation selector 2
::3::{U+FE02} ; variation selector 3
::4::{U+FE03} ; variation selector 4
::5::{U+FE04} ; variation selector 5
::6::{U+FE05} ; variation selector 6
::7::{U+FE06} ; variation selector 7
::8::{U+FE07} ; variation selector 8
::9::{U+FE08} ; variation selector 9"""
mod = re.sub(r'[\x00-\x7F]', '', text)
for i in mod:
    if mod.count(i) > 1: print(i)
```
which returns only this pair.